### PR TITLE
fix: use initial location flow on startup instead of loading default …

### DIFF
--- a/SkyCast — Weather App/Weather-Helper/ContentView.swift
+++ b/SkyCast — Weather App/Weather-Helper/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
             }
             .navigationBarHidden(true)
             .task {
-                await viewModel.loadDefaultWeatherIfNeeded()
+                await viewModel.loadInitialWeatherIfNeeded()
             }
             .alert("ClimaFlow", isPresented: Binding(
                 get: { viewModel.errorMessage != nil },

--- a/SkyCast — Weather App/Weather-Helper/WeatherViewModel.swift
+++ b/SkyCast — Weather App/Weather-Helper/WeatherViewModel.swift
@@ -115,7 +115,11 @@ final class WeatherViewModel: ObservableObject {
             await searchCity(named: name)
 
         case .default:
-            await loadDefaultWeatherIfNeeded()
+            await loadWeather(
+                latitude: 47.3769,
+                longitude: 8.5417,
+                name: "Zurich, Switzerland"
+            )
         }
     }
 


### PR DESCRIPTION
Tested on both physical device and iOS Simulator.

Result:
- App now loads the current location on startup when location permission is already granted.
- Default city no longer loads first during normal startup.
- Physical device behavior looks correct.
- Simulator showed some Core Location / geocoding noise, but startup still loaded My Location first.