### PR TITLE
fix: correct saved city weather icon updates

### DIFF
--- a/SkyCast — Weather App/Weather-Helper/CitiesView.swift
+++ b/SkyCast — Weather App/Weather-Helper/CitiesView.swift
@@ -25,7 +25,6 @@ struct CitiesView: View {
             ZStack {
                 backgroundGradient
                     .ignoresSafeArea()
-                    .animation(.easeInOut(duration: 0.6), value: viewModel.weather?.current.weatherCode ?? -1)
 
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 18) {
@@ -71,7 +70,8 @@ struct CitiesView: View {
                                 .padding(.vertical, 28)
                                 .glassCard(cornerRadius: 22)
                             } else {
-                                ForEach(filteredFavorites) { favorite in
+                                ForEach(filteredFavorites.indices, id: \.self) { index in
+                                    let favorite = filteredFavorites[index]
                                     HStack(spacing: 12) {
                                         Button {
                                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -104,7 +104,7 @@ struct CitiesView: View {
 
                                                 if let snapshot = viewModel.favoriteWeatherSnapshots[favorite.id] {
                                                     HStack(spacing: 10) {
-                                                        Image(systemName: weatherSymbolName(for: snapshot.weatherCode))
+                                                        Image(systemName: weatherSymbolName(for: snapshot.weatherCode, isNight: snapshot.isNight))
                                                             .font(.system(size: 17, weight: .medium))
                                                             .foregroundStyle(.white.opacity(0.88))
                                                             .frame(width: 18)
@@ -143,6 +143,7 @@ struct CitiesView: View {
                     .padding(.bottom, 28)
                     .id(temperatureUnit)
                 }
+                .safeAreaPadding(.top, 20)
                 .task {
                     await viewModel.refreshFavoriteWeatherSnapshots()
                 }
@@ -389,12 +390,12 @@ struct CitiesView: View {
         }
     }
 
-    private func weatherSymbolName(for weatherCode: Int) -> String {
+    private func weatherSymbolName(for weatherCode: Int, isNight: Bool) -> String {
         switch weatherCode {
         case 0:
-            return viewModel.isNight ? "moon.stars.fill" : "sun.max.fill"
+            return isNight ? "moon.stars.fill" : "sun.max.fill"
         case 1, 2:
-            return viewModel.isNight ? "cloud.moon.fill" : "cloud.sun.fill"
+            return isNight ? "cloud.moon.fill" : "cloud.sun.fill"
         case 3:
             return "cloud.fill"
         case 45, 48:

--- a/SkyCast — Weather App/Weather-Helper/WeatherViewModel.swift
+++ b/SkyCast — Weather App/Weather-Helper/WeatherViewModel.swift
@@ -51,6 +51,7 @@ final class WeatherViewModel: ObservableObject {
     struct FavoriteWeatherSnapshot {
         let temperature: Int
         let weatherCode: Int
+        let isNight: Bool
     }
 
     var hourlyForecast: [HourlyForecastItem] {
@@ -63,6 +64,12 @@ final class WeatherViewModel: ObservableObject {
 
     var isNight: Bool {
         guard let today = dailyForecast.first else { return false }
+        let now = Date()
+        return now < today.sunrise || now > today.sunset
+    }
+
+    private func isNight(for weather: WeatherData) -> Bool {
+        guard let today = weather.daily.first else { return false }
         let now = Date()
         return now < today.sunrise || now > today.sunset
     }
@@ -413,7 +420,8 @@ final class WeatherViewModel: ObservableObject {
 
                 snapshots[favorite.id] = FavoriteWeatherSnapshot(
                     temperature: Int(weather.current.temperature.rounded()),
-                    weatherCode: weather.current.weatherCode
+                    weatherCode: weather.current.weatherCode,
+                    isNight: isNight(for: weather)
                 )
             } catch {
                 continue


### PR DESCRIPTION
## 🛠️ Fix: Cities Live Weather Update

This PR fixes an issue where saved cities in the Cities tab displayed incorrect weather icons (e.g. showing sun instead of moon).

---

## ✅ Changes
- Added `isNight` to `FavoriteWeatherSnapshot`
- Implemented per-city day/night calculation using sunrise/sunset
- Updated Cities view to use snapshot-based icon logic
- Ensured each saved city reflects its own local time instead of the current Home location

---

## 🧪 Testing
- Verified on iPhone (real device)
- Tested multiple cities (Los Angeles, Barcelona, Rotenburg)
- Confirmed icons match Home view and local time correctly

---

## 📸 Result
Saved cities now show accurate weather icons based on their own timezone and conditions.

---

## 🚀 Next Steps
- UI consistency & spacing polish across Home, Cities, Settings