### PR TITLE
feat(hero): improve sunny readability and refine contrast

### DIFF
--- a/SkyCast — Weather App/Weather-Helper/HeroWeatherCard.swift
+++ b/SkyCast — Weather App/Weather-Helper/HeroWeatherCard.swift
@@ -9,6 +9,56 @@ struct HeroWeatherCard: View {
     let prefersExtraContrast: Bool
     let onTap: () -> Void
 
+    private var usesStrongSunnyContrast: Bool {
+        prefersExtraContrast && !isNight
+    }
+
+    private var usesSoftContrast: Bool {
+        prefersExtraContrast && isNight
+    }
+
+    private var cardBaseTintOpacity: Double {
+        if usesStrongSunnyContrast { return 0.10 }
+        if usesSoftContrast { return 0.03 }
+        return 0
+    }
+
+    private var cardGradientTopOpacity: Double {
+        if usesStrongSunnyContrast { return 0.16 }
+        if usesSoftContrast { return 0.05 }
+        return 0
+    }
+
+    private var cardGradientMidOpacity: Double {
+        if usesStrongSunnyContrast { return 0.07 }
+        if usesSoftContrast { return 0.02 }
+        return 0
+    }
+
+    private var glassExtraDarkTint: Double {
+        if usesStrongSunnyContrast { return 0.08 }
+        if usesSoftContrast { return 0.03 }
+        return isNight ? 0.04 : 0
+    }
+
+    private var cardStrokeOpacity: Double {
+        if usesStrongSunnyContrast { return 0.18 }
+        if usesSoftContrast { return 0.12 }
+        return 0.10
+    }
+
+    private var cardShadowOpacity: Double {
+        if usesStrongSunnyContrast { return 0.14 }
+        if usesSoftContrast { return 0.08 }
+        return 0.06
+    }
+
+    private var cardShadowRadius: CGFloat {
+        if usesStrongSunnyContrast { return 16 }
+        if usesSoftContrast { return 12 }
+        return 10
+    }
+
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: HomeView.UI.heroCardDetailSpacing) {
@@ -16,14 +66,16 @@ struct HeroWeatherCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Now")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.white.opacity(0.72))
+                            .foregroundStyle(.white.opacity(usesStrongSunnyContrast ? 0.88 : (usesSoftContrast ? 0.80 : 0.72)))
+                            .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.22 : (usesSoftContrast ? 0.14 : 0.10)), radius: usesStrongSunnyContrast ? 2 : 1, x: 0, y: 1)
                     }
 
                     Spacer()
 
                     Image(systemName: "chevron.down.circle.fill")
                         .font(.title3)
-                        .foregroundStyle(.white.opacity(0.92))
+                        .foregroundStyle(.white.opacity(usesStrongSunnyContrast ? 1.0 : (usesSoftContrast ? 0.96 : 0.92)))
+                        .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.20 : (usesSoftContrast ? 0.12 : 0.08)), radius: usesStrongSunnyContrast ? 2 : 1, x: 0, y: 1)
                         .rotationEffect(.degrees(isExpanded ? 180 : 0))
                         .scaleEffect(isExpanded ? 1.06 : 1)
                 }
@@ -34,19 +86,23 @@ struct HeroWeatherCard: View {
                     .scaledToFit()
                     .frame(width: 124, height: 124)
                     .shadow(color: .white.opacity(0.18), radius: 18, x: 0, y: 0)
+                    .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.18 : (usesSoftContrast ? 0.10 : 0.08)), radius: usesStrongSunnyContrast ? 8 : (usesSoftContrast ? 5 : 4), x: 0, y: 4)
 
                 Text(weather.current.temperatureText)
                     .font(.system(size: 68, weight: .semibold))
                     .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.30 : (usesSoftContrast ? 0.18 : 0.14)), radius: usesStrongSunnyContrast ? 4 : (usesSoftContrast ? 3 : 2), x: 0, y: 2)
 
                 Text(weather.current.summary)
                     .font(.title3.weight(.semibold))
                     .foregroundColor(.white)
-                    .opacity(colorScheme == .dark ? HomeView.UI.secondaryTextOpacityDark : HomeView.UI.secondaryTextOpacityLight)
+                    .opacity(usesStrongSunnyContrast ? 0.96 : (usesSoftContrast ? 0.90 : (colorScheme == .dark ? HomeView.UI.secondaryTextOpacityDark : HomeView.UI.secondaryTextOpacityLight)))
+                    .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.22 : (usesSoftContrast ? 0.14 : 0.10)), radius: usesStrongSunnyContrast ? 3 : (usesSoftContrast ? 2 : 1), x: 0, y: 1)
 
                 Text("H: \(weather.todayHighText)   L: \(weather.todayLowText)")
                     .font(.headline.weight(.medium))
-                    .foregroundStyle(.white.opacity(0.92))
+                    .foregroundStyle(.white.opacity(usesStrongSunnyContrast ? 0.98 : (usesSoftContrast ? 0.94 : 0.92)))
+                    .shadow(color: .black.opacity(usesStrongSunnyContrast ? 0.18 : (usesSoftContrast ? 0.10 : 0.08)), radius: usesStrongSunnyContrast ? 2 : 1, x: 0, y: 1)
 
                 if isExpanded {
                     VStack(spacing: HomeView.UI.heroCardDetailSpacing) {
@@ -82,9 +138,28 @@ struct HeroWeatherCard: View {
             .padding(.horizontal, HomeView.UI.heroCardInnerPadding)
             .background {
                 RoundedRectangle(cornerRadius: HomeView.UI.heroCardCornerRadius, style: .continuous)
-                    .fill(Color.black.opacity(prefersExtraContrast ? 0.06 : 0))
+                    .fill(Color.black.opacity(cardBaseTintOpacity))
             }
-            .glassCard(cornerRadius: HomeView.UI.heroCardCornerRadius, extraDarkTint: isNight ? 0.04 : 0)
+            .overlay {
+                RoundedRectangle(cornerRadius: HomeView.UI.heroCardCornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.black.opacity(cardGradientTopOpacity),
+                                Color.black.opacity(cardGradientMidOpacity),
+                                Color.clear
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            }
+            .glassCard(cornerRadius: HomeView.UI.heroCardCornerRadius, extraDarkTint: glassExtraDarkTint)
+            .overlay {
+                RoundedRectangle(cornerRadius: HomeView.UI.heroCardCornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(cardStrokeOpacity), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(cardShadowOpacity), radius: cardShadowRadius, x: 0, y: 8)
             .scaleEffect(isExpanded ? 1.01 : 1.0)
             .contentShape(Rectangle())
         }
@@ -98,15 +173,55 @@ private struct HeroWeatherDetailItem: View {
     let systemImage: String
     let prefersExtraContrast: Bool
 
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var tileFillOpacity: Double {
+        if colorScheme == .dark {
+            return prefersExtraContrast ? 0.14 : 0.09
+        }
+        return prefersExtraContrast ? 0.12 : 0.07
+    }
+
+    private var tileStrokeOpacity: Double {
+        if colorScheme == .dark {
+            return prefersExtraContrast ? 0.20 : 0.12
+        }
+        return prefersExtraContrast ? 0.18 : 0.10
+    }
+
+    private var tileShadowOpacity: Double {
+        if colorScheme == .dark {
+            return prefersExtraContrast ? 0.06 : 0.02
+        }
+        return prefersExtraContrast ? 0.08 : 0.00
+    }
+
+    private var tileShadowRadius: CGFloat {
+        if colorScheme == .dark {
+            return prefersExtraContrast ? 4 : 2
+        }
+        return prefersExtraContrast ? 6 : 0
+    }
+
+    private var labelOpacity: Double {
+        prefersExtraContrast ? 0.98 : 0.72
+    }
+
+    private var labelShadowOpacity: Double {
+        prefersExtraContrast ? 0.16 : 0.06
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: HomeView.UI.heroDetailRowSpacing) {
             Label(title, systemImage: systemImage)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.white.opacity(prefersExtraContrast ? 0.96 : 0.72))
+                .foregroundStyle(.white.opacity(labelOpacity))
+                .shadow(color: .black.opacity(labelShadowOpacity), radius: prefersExtraContrast ? 2 : 1, x: 0, y: 1)
 
             Text(value)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.white)
+                .shadow(color: .black.opacity(labelShadowOpacity), radius: prefersExtraContrast ? 2 : 1, x: 0, y: 1)
                 .multilineTextAlignment(.leading)
                 .lineLimit(2)
                 .minimumScaleFactor(0.85)
@@ -115,11 +230,12 @@ private struct HeroWeatherDetailItem: View {
         .padding(12)
         .background {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color.white.opacity(prefersExtraContrast ? 0.10 : 0.07))
+                .fill(Color.white.opacity(tileFillOpacity))
                 .overlay(
                     RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .strokeBorder(Color.white.opacity(prefersExtraContrast ? 0.14 : 0.10), lineWidth: 1)
+                        .strokeBorder(Color.white.opacity(tileStrokeOpacity), lineWidth: 1)
                 )
+                .shadow(color: .black.opacity(tileShadowOpacity), radius: tileShadowRadius, x: 0, y: 3)
         }
     }
 }


### PR DESCRIPTION
## 🎯 Improve hero card readability in bright/sunny conditions ☀️

This update enhances the readability of the hero weather card, especially in bright outdoor conditions, while preserving the modern glass-style design.

---

### ✨ What’s improved

- Improved visibility in sunny environments with adaptive contrast
- Added subtle dark tint and gradient overlays for better legibility
- Refined text shadows for clearer temperature and labels
- Enhanced dark mode with better depth and hierarchy
- Slightly lifted detail tiles for improved visual separation

---

### 🎨 Design approach

The goal was to **increase readability without compromising the glass aesthetic**.  
All changes are subtle and adaptive based on:
- Weather conditions (sunny vs cloudy)
- Time of day (day vs night)
- System appearance (light / dark mode)

---

### ✅ Result

- Better outdoor readability ☀️  
- Cleaner visual hierarchy  
- Consistent, premium UI across the app  

---

### 🧪 Testing

Tested across:
- Sunny, cloudy, and night conditions
- Light and dark mode
- Expand / collapse interactions
- Navigation between Home, Cities, and Settings

---

### 📌 Notes

This is a focused UI/UX improvement for the hero card.  
Other screens remain unchanged to preserve overall design consistency